### PR TITLE
make build-bash reach qmstr server on port 9000, not 8080

### DIFF
--- a/build-bash.sh
+++ b/build-bash.sh
@@ -16,7 +16,7 @@ fi
 ~/go/bin/qmstr-master &
 make -j5
 
-curl http://localhost:8080/report?id=bash
+curl http://localhost:9000/report?id=bash
 
-curl http://localhost:8080/quit
+curl http://localhost:9000/quit
 


### PR DESCRIPTION
Demo build-bash.sh queries the server on port 8080, althought it is configured to listen to port 9000, just changing the client side to port 9000